### PR TITLE
feat: ページタイトルコンポーネントの実装

### DIFF
--- a/src/components/about/AboutPage/AboutPage.tsx
+++ b/src/components/about/AboutPage/AboutPage.tsx
@@ -1,6 +1,7 @@
 import { FC } from 'react'
 
 import { BreadCrumb } from '@/components/common/BreadCrumb/BreadCrumb'
+import { PageTitle } from '@/components/common/PageTitle/PageTitle'
 import { pageLinkObject } from '@/constants/pageLinks'
 
 import { AboutAccordion } from '../AboutAccordion/AboutAccordion'
@@ -16,7 +17,7 @@ export const AboutPage: FC<AboutPageProps> = ({ ...props }) => {
                     { label: pageLinkObject.ABOUT.text },
                 ]}
             />
-            <h1 className='my-12 px-12 text-title'>京大マーケティング研究所について</h1>
+            <PageTitle>京大マーケティング研究所について</PageTitle>
             <div className='mb-12 px-6'>
                 <AboutAccordion />
             </div>

--- a/src/components/articles/ArticlesPage/ArticlesPage.tsx
+++ b/src/components/articles/ArticlesPage/ArticlesPage.tsx
@@ -1,6 +1,7 @@
 import { FC, Suspense } from 'react'
 
 import { BreadCrumb } from '@/components/common/BreadCrumb/BreadCrumb'
+import { PageTitle } from '@/components/common/PageTitle/PageTitle'
 import { pageLinkObject } from '@/constants/pageLinks'
 
 import ActivityArticleList from '../ActivityArticleList/ActivityArticleList'
@@ -21,8 +22,8 @@ export const ArticlesPage: FC<ArticlesPageProps> = ({ page, tag, ...props }) => 
                     { label: pageLinkObject.ARCHIVE.text },
                 ]}
             />
+            <PageTitle>{pageLinkObject.ARCHIVE.text}</PageTitle>
             <div className='px-4 pb-12'>
-                <h1 className='my-12 text-center text-xl font-bold'>活動記録</h1>
                 <div className='mb-12 space-y-4 px-4'>
                     <p>京大マーケティング研究所の部員の普段の活動を記録していきます。</p>
                     <p>

--- a/src/components/common/PageTitle/PageTitle.stories.tsx
+++ b/src/components/common/PageTitle/PageTitle.stories.tsx
@@ -1,0 +1,17 @@
+import { PageTitle } from './PageTitle'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta = {
+    component: PageTitle,
+    tags: ['autodocs'],
+    parameters: {},
+    args: {
+        children: 'タイトル',
+    },
+} satisfies Meta<typeof PageTitle>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/src/components/common/PageTitle/PageTitle.tsx
+++ b/src/components/common/PageTitle/PageTitle.tsx
@@ -1,0 +1,10 @@
+import { FC } from 'react'
+
+export interface PageTitleProps {
+    children: string
+}
+
+/** 各ページのタイトル */
+export const PageTitle: FC<PageTitleProps> = ({ ...props }) => {
+    return <h1 className='my-12 px-12 text-title' {...props} />
+}

--- a/src/components/common/PageTitle/PageTitle.tsx
+++ b/src/components/common/PageTitle/PageTitle.tsx
@@ -5,6 +5,10 @@ export interface PageTitleProps {
 }
 
 /** 各ページのタイトル */
-export const PageTitle: FC<PageTitleProps> = ({ ...props }) => {
-    return <h1 className='my-12 px-12 text-title' {...props} />
+export const PageTitle: FC<PageTitleProps> = ({ children, ...props }) => {
+    return (
+        <div className='my-12 w-full px-12 text-title' {...props}>
+            <h1 className='mx-auto w-fit'>{children}</h1>
+        </div>
+    )
 }

--- a/src/components/contact/ContactPage/ContactPage.tsx
+++ b/src/components/contact/ContactPage/ContactPage.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 
+import { PageTitle } from '@/components/common/PageTitle/PageTitle'
 import { pageLinkObject } from '@/constants/pageLinks'
 
 import { BreadCrumb } from '../../common/BreadCrumb/BreadCrumb'
@@ -17,9 +18,9 @@ export const ContactPage: FC<ContactPageProps> = ({ ...props }) => {
                     { label: pageLinkObject.CONTACT.text },
                 ]}
             />
+            <PageTitle>{pageLinkObject.CONTACT.text}</PageTitle>
             <div>
                 <div className='space-y-2 p-4'>
-                    <h1 className='text-xl font-bold'>お問い合わせ</h1>
                     <p className='text-gray-700'>以下のフォームからご自由にお問い合わせください。</p>
                 </div>
                 <div className='px-4 py-8'>

--- a/src/components/contact/ContactSuccessPage/ContactSuccessPage.tsx
+++ b/src/components/contact/ContactSuccessPage/ContactSuccessPage.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 
+import { PageTitle } from '@/components/common/PageTitle/PageTitle'
 import { pageLinkObject } from '@/constants/pageLinks'
 
 import { BreadCrumb } from '../../common/BreadCrumb/BreadCrumb'
@@ -17,8 +18,8 @@ export const ContactSuccessPage: FC<ContactSuccessPageProps> = ({ ...props }) =>
                     { label: '送信完了' },
                 ]}
             />
-            <div className='p-8'>
-                <h1 className='mb-12 text-center text-xl font-bold'>送信が完了しました</h1>
+            <PageTitle>送信が完了しました</PageTitle>
+            <div className='mb-12 px-8'>
                 <div className='space-y-4'>
                     <p>お問い合わせありがとうございます。</p>
                     <p>内容を確認の上、近日中に担当者からご連絡いたします。</p>


### PR DESCRIPTION
各ページのタイトルは共通のレイアウトをもっているのでコンポーネントで共通化