### PR TITLE
feat: トップメッセージの背景に透明度をもたせる

### DIFF
--- a/src/components/top/TopPage/TopPage.tsx
+++ b/src/components/top/TopPage/TopPage.tsx
@@ -65,9 +65,9 @@ export const TopPage: FC<TopPageProps> = async ({ ...props }) => {
                         >
                             <Link href='/about'>サークルについて</Link>
                         </Button>
-                        <div className='w-fit max-w-[75%] bg-background px-12 py-8 text-foreground'>
-                            <h2 className='ml-4 text-xl'>{message}</h2>
-                            <p className='whitespace-pre-wrap pt-4 text-sm'>{subMessage}</p>
+                        <div className='w-fit max-w-[75%] bg-background/90 px-12 py-8 text-foreground'>
+                            <h2 className='ml-4 text-xl drop-shadow'>{message}</h2>
+                            <p className='whitespace-pre-wrap pt-4 text-sm drop-shadow'>{subMessage}</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
デザインの観点でどっちがいいか検討中

メッセージの面積が大きいと、せっかくの画像が隠れてしまうので背景を少し透過して画像を活かそうという意図がある  
デメリットとしては、メッセージが読みにくいとか単純にダサいとかが考えられる